### PR TITLE
Update README and package.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,28 +1,10 @@
-# all-turtle-sanity-translations-tab
-
-This is forked from Sanity's translations-tab, and may either be published by us at AT or pushed back to Sanity for V2 of their plugin. We'll see where this goes!
-
-## Plugin development
-
-To develop and test this plugin locally, you'll need a Sanity studio that has a custom desk structure using `TranslationsTab` (see implementation of [Studio Plugin for Sanity & Smartling](https://github.com/sanity-io/sanity-plugin-studio-smartling)) and a [symlink](https://medium.com/dailyjs/how-to-use-npm-link-7375b6219557) configured to run `TranslationsTab` from this local development version.
-
-1. Clone this repo locally in its own directory (not as part of a studio)
-2. Run `npm install` to install the plugin's dependencies.
-3. Run `npm link` from this plugin's directory (eg, `~/code/sanity-translations-tab`) to create a global symlink to this local instance of the `sanity-translations-tab` dependency.
-4. Run `npm run build` to compile an initial version.
-5. Run `npm link sanity-translations-tab` inside the directory of the studio you want to use the plugin in (eg, `~/code/mmhmm-sanity`). This will tell the studio application to use the global symlink to this instance of the dependency.
-6. Add `import { TranslationsTab } from 'sanity-translations-tab'` to `deskStructure.js` in the studio. If previously importing `TranslationsTab` from `sanity-plugin-smartling-studio`, remove that import statement.
-7. Run `sanity start` to run the studio locally.
-8. Run `npm run watch` from the `sanity-translations-tab` directory to start a watch task.
-9. Start making changes to the translations tab, as needed, and they should automatically compile in the studio in the browser.
-
----
-
 # sanity-translations-tab [original docs]
 
 This is the base module for implementing common translation vendor tasks from a Studio, such as sending content to be translated in some specific languages, importing content back etc. Not useful on its own, but a vendor specific plugin will use this for its chrome.
 
-## Development
+For guidelines on contributing to this document
+
+## In-studio development
 
 1. Clone this repo into a Studio's `plugins` directory.
 2. Add `"sanity-translations-tab"` to the `plugins` key of `sanity.json`
@@ -72,3 +54,22 @@ npx parcel example/index.html
 ```
 
 to run the component in a dev server
+
+## Isolated development
+
+To develop this plugin as a separate repository (outside of your studio environment) and test it locally in a studio during development, you'll need:
+
+- a Sanity studio with a custom desk structure that uses `TranslationsTab` (see implementation of [Studio Plugin for Sanity & Smartling](https://github.com/sanity-io/sanity-plugin-studio-smartling))
+- a [symlink](https://medium.com/dailyjs/how-to-use-npm-link-7375b6219557) configured to run `TranslationsTab` from this local development version.
+
+Assuming you already have a studio, the following will get you up and running with a forked repo and symlink:
+
+1. Fork or clone this repo locally in its own directory (not as part of a studio)
+2. Run `npm install` to install the plugin's dependencies.
+3. Run `npm link` from this plugin's directory (eg, `~/code/sanity-translations-tab`) to create a global symlink to this local instance of the `sanity-translations-tab` dependency.
+4. Run `npm run build` to compile an initial version.
+5. Run `npm link sanity-translations-tab` inside the directory of the studio you want to use the plugin in (eg, `~/code/my-studio`). This will tell the studio application to use the global symlink to this instance of the dependency.
+6. Add `import { TranslationsTab } from 'sanity-translations-tab'` to `deskStructure.js` in the studio. If previously importing `TranslationsTab` from an adapter library such as `sanity-plugin-smartling-studio`, remove that import statement.
+7. Run `sanity start` to run the studio locally.
+8. Run `npm run watch` from the `sanity-translations-tab` directory to start a watch task.
+9. Start making changes to the translations tab, as needed, and they should automatically compile in the studio in the browser.

--- a/package.json
+++ b/package.json
@@ -38,7 +38,10 @@
     "trailingComma": "es5"
   },
   "name": "sanity-translations-tab",
-  "author": "Sanity.io/All Turtles",
+  "author": "Sanity.io",
+  "contributors": [
+    "annie@all-turtles.com"
+  ],
   "module": "dist/sanity-translations-tab.esm.js",
   "size-limit": [
     {


### PR DESCRIPTION
Updates README content for general use so this can be merged upstream
into the original repo. Includes original "Development" section, renamed 
"In-studio development," and moves the section I added about how to get
a separate repo running locally with a symlink to the end.