### PR TITLE
Refresh task on create job; provide manual refresh

### DIFF
--- a/src/components/NewTask.tsx
+++ b/src/components/NewTask.tsx
@@ -110,7 +110,6 @@ export const NewTask = ({ locales, refreshTask }: Props) => {
         /** Reset form fields */
         setSelectedLocales([])
         setSelectedWorkflowUid('')
-        setIsBusy(false)
 
         /** Update task data in TranslationView */
         refreshTask()
@@ -129,6 +128,9 @@ export const NewTask = ({ locales, refreshTask }: Props) => {
           status: 'error',
           closable: true,
         })
+      })
+      .finally(() => {
+        setIsBusy(false)
       })
   }
 

--- a/src/components/TaskView.tsx
+++ b/src/components/TaskView.tsx
@@ -1,5 +1,5 @@
-import React, { useContext } from 'react'
-import { Box, Text, Stack, useToast } from '@sanity/ui'
+import React, { useContext, useState } from 'react'
+import { Box, Button, Flex, Text, Stack, useToast } from '@sanity/ui'
 
 import { TranslationContext } from './TranslationContext'
 import { TranslationLocale, TranslationTask } from '../types'
@@ -8,6 +8,7 @@ import { LanguageStatus } from './LanguageStatus'
 type JobProps = {
   task: TranslationTask
   locales: TranslationLocale[]
+  refreshTask: () => Promise<void>
 }
 
 const getLocale = (
@@ -15,9 +16,11 @@ const getLocale = (
   locales: TranslationLocale[]
 ): TranslationLocale | undefined => locales.find(l => l.localeId === localeId)
 
-export const TaskView = ({ task, locales }: JobProps) => {
+export const TaskView = ({ task, locales, refreshTask }: JobProps) => {
   const context = useContext(TranslationContext)
   const toast = useToast()
+
+  const [isRefreshing, setIsRefreshing] = useState(false)
 
   const importFile = async (localeId: string) => {
     if (!context) {
@@ -66,11 +69,28 @@ export const TaskView = ({ task, locales }: JobProps) => {
     }
   }
 
+  const handleRefreshClick = async () => {
+    setIsRefreshing(true)
+    await refreshTask()
+    setIsRefreshing(false)
+  }
+
   return (
     <Stack space={4}>
-      <Text as="h2" weight="semibold" size={2}>
-        Current Job Progress
-      </Text>
+      <Flex align="center" justify="space-between">
+        <Text as="h2" weight="semibold" size={2}>
+          Current Job Progress
+        </Text>
+
+        <Button
+          fontSize={1}
+          padding={2}
+          text={isRefreshing ? 'Refreshing' : 'Refresh Status'}
+          onClick={handleRefreshClick}
+          disabled={isRefreshing}
+        />
+      </Flex>
+
       <Box>
         {task.locales.map(localeTask => {
           const reportPercent = localeTask.progress || 0

--- a/src/components/TranslationView.tsx
+++ b/src/components/TranslationView.tsx
@@ -4,7 +4,7 @@
  */
 
 import React, { useContext, useEffect, useState } from 'react'
-import { Stack } from '@sanity/ui'
+import { Stack, useToast } from '@sanity/ui'
 import { TranslationContext } from './TranslationContext'
 
 import { NewTask } from './NewTask'
@@ -16,31 +16,61 @@ export const TranslationView = () => {
   const [task, setTask] = useState<TranslationTask | null>(null)
 
   const context = useContext(TranslationContext)
+  const toast = useToast()
 
   useEffect(() => {
     async function fetchData() {
       if (!context) {
-        console.error('Missing context')
+        toast.push({
+          title: 'Unable to load translation data: missing context',
+          status: 'error',
+          closable: true,
+        })
         return
       }
+
       context.adapter
         .getLocales(context.secrets)
         .then(setLocales)
         .then(() =>
-          context.adapter.getTranslationTask(
+          context?.adapter.getTranslationTask(
             context.documentId,
             context.secrets
           )
         )
         .then(setTask)
+        .catch(err => {
+          let errorMsg
+          if (err instanceof Error) {
+            errorMsg = err.message
+          } else {
+            errorMsg = err ? String(err) : null
+          }
+
+          toast.push({
+            title: `Error creating translation job`,
+            description: errorMsg,
+            status: 'error',
+            closable: true,
+          })
+        })
     }
+
     fetchData()
-  }, [context])
+  }, [context, toast])
+
+  const refreshTask = async () => {
+    await context?.adapter
+      .getTranslationTask(context.documentId, context.secrets)
+      .then(setTask)
+  }
 
   return (
     <Stack space={6}>
-      <NewTask locales={locales} />
-      {task && <TaskView task={task} locales={locales} />}
+      <NewTask locales={locales} refreshTask={refreshTask} />
+      {task && (
+        <TaskView task={task} locales={locales} refreshTask={refreshTask} />
+      )}
     </Stack>
   )
 }


### PR DESCRIPTION
To provide a more transparent experience when creating a new job:
  - Display error toast if unable to load translations or create job due to missing `context` or if error is thrown while creating task
  - Set loading text on "Create job" button while processing
  - Show success toast on successful job creation
  - After successful job creation, reset form and get refreshed task
  - Because, in my testing experience, the newly added locale isn't always available immediately upon job creation, provide a "Refresh status" button so the user can grab it fresh themselves, without reloading page.

![Screen Shot 2022-02-16 at 5 49 52 PM](https://user-images.githubusercontent.com/11039888/154391702-3c5f1cab-6215-49c6-aad7-befd5eca72a9.png)
